### PR TITLE
Fix TableColumn\Label for null values

### DIFF
--- a/src/TableColumn/Labels.php
+++ b/src/TableColumn/Labels.php
@@ -32,7 +32,7 @@ class Labels extends Generic
         $v = is_string($v) ? explode(',', $v) : $v;
 
         $labels= [];
-        foreach ($v as $id) {
+        foreach ((Array) $v as $id) {
             $id = trim($id);
 
             // if field values is set, then use titles instead of IDs


### PR DESCRIPTION
When $field->get() returns null cast to empry Array to avoid foreach error.

Implementation of `<new feature>` (see ticket #..). Simple use:

``` php
Component::addTo($app);
..
```

Typical use case of new feature explained here.

Drag a SCREENSHOT here:

 - Documentation: [docs/file.rst](docs/file.rst)
 - Demo: [demos/file.php](demos/file.php)

p.s. set label "in review" and assign reviewers if PR is complete. Otherwise set "work in progress" label.
